### PR TITLE
Week4 work

### DIFF
--- a/index-data.sh
+++ b/index-data.sh
@@ -4,10 +4,10 @@ usage()
   exit 2
 }
 
-PRODUCTS_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_products.json"
-QUERIES_JSON_FILE="/workspace/search_with_machine_learning_course/opensearch/bbuy_queries.json"
+PRODUCTS_JSON_FILE="/workspace/search_with_machine_learning_course/week4/conf/bbuy_products.json"
+QUERIES_JSON_FILE="/workspace/search_with_machine_learning_course/week4/conf/bbuy_queries.json"
 
-PRODUCTS_LOGSTASH_FILE="/workspace/search_with_machine_learning_course/logstash/index-bbuy.logstash"
+PRODUCTS_LOGSTASH_FILE="/workspace/search_with_machine_learning_course/week4/conf/index-bbuy-http-filter.logstash"
 QUERIES_LOGSTASH_FILE="/workspace/search_with_machine_learning_course/logstash/index-bbuy-queries.logstash"
 
 LOGSTASH_HOME="/workspace/logstash/logstash-7.13.2"

--- a/week2/conf/ltr_featureset.json
+++ b/week2/conf/ltr_featureset.json
@@ -138,6 +138,7 @@
             "functions": [
               {
                 "field_value_factor": {
+                  "field": "salesRankMediumTerm",
                   "missing": 120000
                 }
               }

--- a/week4/__init__.py
+++ b/week4/__init__.py
@@ -12,7 +12,7 @@ def create_app(test_config=None):
     if test_config is None:
         # load the instance config, if it exists, when not testing
         app.config.from_pyfile('config.py', silent=True)
-        QUERY_CLASS_MODEL_LOC = os.environ.get("QUERY_CLASS_MODEL_LOC", "/workspace/datasets/fasttext/query_model.bin")
+        QUERY_CLASS_MODEL_LOC = os.environ.get("QUERY_CLASS_MODEL_LOC", "/workspace/datasets/min_1000_preprocessed/query_model.bin")
         if QUERY_CLASS_MODEL_LOC and os.path.isfile(QUERY_CLASS_MODEL_LOC):
             app.config["query_model"] = fasttext.load_model(QUERY_CLASS_MODEL_LOC)
         else:

--- a/week4/conf/index-bbuy-http-filter.logstash
+++ b/week4/conf/index-bbuy-http-filter.logstash
@@ -1,6 +1,6 @@
 input {
   file {
-    path => ["/workspace/datasets/product_data/products/*.xml"]  #Put in the path to the ungzipped/untarred product data.  To start smaller, simply select a smaller number of files or copy a few files to a different directory.
+    path => ["/workspace/search_with_machine_learning_course/data/pruned_products/*.xml"]  #Put in the path to the ungzipped/untarred product data.  To start smaller, simply select a smaller number of files or copy a few files to a different directory.
     start_position => "beginning"
     codec => multiline {
             pattern => "<product>"

--- a/week4/create_labeled_queries.py
+++ b/week4/create_labeled_queries.py
@@ -7,7 +7,11 @@ import csv
 
 # Useful if you want to perform stemming.
 import nltk
-stemmer = nltk.stem.PorterStemmer()
+import string
+from nltk import word_tokenize
+from nltk.corpus import stopwords
+from nltk.stem import SnowballStemmer
+from nltk import pos_tag
 
 categories_file_name = r'/workspace/datasets/product_data/categories/categories_0001_abcat0010000_to_pcmcat99300050000.xml'
 
@@ -50,6 +54,20 @@ df = pd.read_csv(queries_file_name)[['category', 'query']]
 df = df[df['category'].isin(categories)]
 
 # IMPLEMENT ME: Convert queries to lowercase, and optionally implement other normalization, like stemming.
+def preprocess_text(query):
+    query = query.lower()
+    query = query.translate(str.maketrans('', '', string.punctuation))
+    
+    words = word_tokenize(query)
+    stop_words = stopwords.words('english')
+    stop_words = set(stop_words)
+    filtered_words = [word for word in words if word not in stop_words]
+    
+    stemmer = SnowballStemmer("english")
+    stemmed = [stemmer.stem(word) for word in filtered_words]
+    return " ".join(stemmed)
+print("preprocessing query text...")
+df['query'] = df['query'].apply(lambda q: preprocess_text(q))
 
 # IMPLEMENT ME: Roll up categories to ancestors to satisfy the minimum number of queries per category.
 category_counts = df['category'].value_counts()
@@ -67,4 +85,4 @@ df['label'] = '__label__' + df['category']
 df = df[df['category'].isin(categories)]
 print(df['category'].value_counts())
 df['output'] = df['label'] + ' ' + df['query']
-df[['output']].to_csv(output_file_name, header=False, sep='|', escapechar='\\', quoting=csv.QUOTE_NONE, index=False)
+df[['output']].sample(frac=1, random_state=123).to_csv(output_file_name, header=False, sep='|', escapechar='\\', quoting=csv.QUOTE_NONE, index=False)

--- a/week4/search.py
+++ b/week4/search.py
@@ -66,8 +66,12 @@ def process_filters(filters_input):
 def get_query_category(user_query, query_class_model):
     user_query = preprocess_text(user_query)
     print("Preprocessed user query: {}".format(user_query))
+    if not user_query:
+        return None
+
     results = query_class_model.predict(user_query, k=5, threshold=0.0)
-    zipped_results = list(zip(results[0], results[1]))
+    cat_ids = [id.replace("__label__","") for id in results[0]]
+    zipped_results = list(zip(cat_ids, results[1]))
     print("fastText classifier output: {}".format(zipped_results))
     return zipped_results
 
@@ -162,8 +166,29 @@ def query():
 
     query_class_model = current_app.config["query_model"]
     query_category = get_query_category(user_query, query_class_model)
-    if query_category is not None:
-        print("IMPLEMENT ME: add this into the filters object so that it gets applied at search time.  This should look like your `term` filter from week 1 for department but for categories instead")
+    if query_category is not None and query_category:
+        #filter regardless of score, add all category ids to terms filter for field categoryPathIds.keyword
+        filter_terms = {
+            "terms": {
+                "categoryPathIds.keyword": [category[0] for category in query_category]
+            }
+        }
+        query_obj['query']['bool']['filter'].append(filter_terms)
+
+        #boost if score is gte 0.6, add category id to term query for field categoryLeaf.keyword under should clause
+        #since rollup is performed it might be possible that predicted categories will never be present in categoryLeaf field (will be present in categoryPathIds)
+        for category, score in query_category:
+            if score >= 0.6:
+                should_term = {
+                    "term": {
+                        "categoryLeaf.keyword": {
+                        "value": category,
+                        "boost": 50
+                        }
+                    }
+                }
+                query_obj['query']['bool']['should'].append(should_term)
+
     print("query obj: {}".format(query_obj))
     response = opensearch.search(body=query_obj, index=current_app.config["index_name"], explain=explain)
     # Postprocess results here if you so desire


### PR DESCRIPTION
**1. For query classification:
a. How many unique categories did you see in your rolled up training data when you set the minimum number of queries per category to 100? To 1000?**
Getting the unique categories and their counts using `df['category'].value_counts()`, at first I got 1486 unique categories.
<img width="299" alt="image" src="https://user-images.githubusercontent.com/47989178/158013185-eb6a1f47-6db1-4fa9-b985-36dca34d474d.png">
When the minimum number of queries per category is set to 100, I got 866 unique categories.
<img width="299" alt="image" src="https://user-images.githubusercontent.com/47989178/158013224-07c55509-7af7-4892-b0c9-38914910ebc2.png">
When the minimum number of queries per category is set to 1000, I got 374 unique categories.
<img width="299" alt="image" src="https://user-images.githubusercontent.com/47989178/158013391-66eac511-b139-4ccb-bb74-6311fb7bdff3.png">


**b. What values did you achieve for P@1, R@3, and R@5? You should have tried at least a few different models, varying the minimum number of queries per category as well as trying different fastText parameters or query normalization. Report at least 3 of your runs.**
<google-sheets-html-origin><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->

  | Model 1 | Model 2 | Model 3 | Model 4
-- | -- | -- | -- | --
min queries | 100 | 1000 | 100 | 1000
preprocessed text | FALSE | FALSE | TRUE | TRUE
learning rate | 0.5 | 0.5 | 0.5 | 0.5
epochs | 25 | 25 | 25 | 25
word ngrams | 2 | 2 | 2 | 2
P@1 | 0.493 | 0.504 | 0.514 | 0.522
R@3 | 0.674 | 0.686 | 0.695 | 0.706
R@5 | 0.739 | 0.749 | 0.757 | 0.77

After the data is prepared by `create_labeled_queries.py`, I shuffled the data and took the first 50000 values as training data, and the last 50000 as testing data, according to the reading. Only the minimum number of queries per category and preprocessing is varied during the different runs. Training parameters were held constant (non default values are set according to the table above), and the default loss function softmax is used. Both performing preprocessing and increasing min queries (at the cost of losing resolution in predicted categories) are deemed to increase the performance of the model, and I will be using model 4 moving forward.


**2.For integrating query classification with search:**
I have implemented both filtering and boosting. 5 predictions are obtained with no threshold from the model. The filtering and boosting is then implemented as follows:
<img width="836" alt="image" src="https://user-images.githubusercontent.com/47989178/158055757-9550323c-c321-4584-8508-6e9bce28bcd5.png">


**a. Give 2 or 3 examples of queries where you saw a dramatic positive change in the results because of filtering. Make sure to include the classifier output for those queries.**
Query: "ipad 2"
Classifier output: `Your query categorization model predicted: [('pcmcat209000050007', 0.760281503200531), ('pcmcat218000050000', 0.08647284656763077), ('pcmcat209000050008', 0.030620116740465164), ('pcmcat218000050003', 0.026567159220576286), ('pcmcat217900050000', 0.023749062791466713)]`
According to the code above, results with category `pcmcat209000050007` (or `iPad`) are boosted and hence the top results were all variations of iPad 2, followed by variations of other iPads, and then finally accessories related to the iPads, which is desirable.

Query: "lcd tv"
Classifier output: `Your query categorization model predicted: [('abcat0101001', 0.9857031106948853), ('pcmcat200900050015', 0.006267087999731302), ('abcat0106004', 0.0047890073619782925), ('pcmcat233200050010', 0.0013648761669173837), ('abcat0101005', 0.0004192907072138041)]`
Results with category `abcat0101001` (or `All Flat-Panel TVs`) are boosted. The first result not of the `All Flat-Panel TVs` category is of the category `abcat0101005` (or `TV/DVD Combos`) and is ranked at 34th, which is desirable.


**b. Given 2 or 3 examples of queries where filtering hurt the results, either because the classifier was wrong or for some other reason. Again, include the classifier output for those queries.**
Query: "ps3"
Classifier output: `Your query categorization model predicted: [('abcat0703001', 0.5304310917854309), ('abcat0703002', 0.16260522603988647), ('pcmcat232900050029', 0.06001700833439827), ('abcat0715007', 0.05300392210483551), ('pcmcat144700050004', 0.044538553804159164)]`
The score of `abcat0703001` (or `PS3 Consoles`) is slightly below the threshold of 0.6. Hence no particular category is boosted, and the actual PS3 console results are not boosted to the top. Instead, the top results are of categories `PS3 Accessories`, `PS3 Games`, `PS3 Controllers` etc. This can be rectified by fine tuning the threshold of 0.6.

Query: "transformers"
Classifier output: `Your query categorization model predicted: [('cat02015', 0.7603320479393005), ('abcat0707002', 0.12136812508106232), ('pcmcat209000050008', 0.019910454750061035), ('cat02685', 0.01568685658276081), ('abcat0703002', 0.008503180928528309)]`
Firstly, the predicted category with the highest score `cat02015` does not exist for any result (I performed a match query as such:
`{
          "match": {
            "categoryPathIds": "cat02015"
          }
        }`). Could be due to information loss during rollup or an error in the data processing. Secondly, the top results are mostly of category with the second highest score `abcat0707002` (or `Nintendo DS Games`), including games which do not contain the word "transformers" at all. Hence, the outcome is undesirable as the user might not be searching for Nintendo DS games.

